### PR TITLE
[WIP] Fixing Travis build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# pulp puppet module
+# Pulp puppet module 
+[![Build Status](https://travis-ci.org/pulp/puppet_deployment.svg?branch=master)](https://travis-ci.org/pulp/puppet_deployment)
 
 ####Table of Contents
 

--- a/Rakefile
+++ b/Rakefile
@@ -4,5 +4,6 @@ PuppetLint.configuration.log_format = '%{path}:%{linenumber}:%{KIND}: %{message}
 PuppetLint.configuration.fail_on_warnings = true
 PuppetLint.configuration.send("disable_class_inherits_from_params_class")
 PuppetLint.configuration.send("disable_80chars")
+PuppetLint.configuration.send('disable_autoloader_layout')
 
 task :default => [:lint]

--- a/manifests/admin.pp
+++ b/manifests/admin.pp
@@ -5,7 +5,7 @@ class pulp::admin (
     $pulp_port                  = 443,
     $pulp_api_prefix            = '/pulp/api',
     $pulp_rsa_pub               = '/etc/pki/pub/admin/server/rsa_pub.key',
-    $verify_ssl                 = 'true',
+    $verify_ssl                 = true,
     $ca_path                    = '/etc/pki/tls/certs/ca-bundle.crt',
     $upload_chunk_size          = '1048576',
     $client_role                = 'admin',
@@ -16,8 +16,8 @@ class pulp::admin (
     $log_filename               = '~/.pulp/admin.log',
     $call_log_filename          = undef, #Default = '~/.pulp/server_calls.log'
     $poll_frequency             = '1',
-    $color_output               = 'true',
-    $wrap_terminal              = 'false',
+    $color_output               = true,
+    $wrap_terminal              = false,
     $wrap_width                 = 80,
 ) inherits pulp::globals {
     exec { 'yum install pulp-admin':
@@ -33,4 +33,3 @@ class pulp::admin (
         mode    => '0644',
     }
 }
-    

--- a/manifests/consumer/register.pp
+++ b/manifests/consumer/register.pp
@@ -2,7 +2,6 @@
 # Use pulp::consumer instead.
 
 class pulp::consumer::register {
-      
   if( $pulp::consumer::pulp_login != undef ) and ( $pulp::consumer::pulp_password != undef ) {
     exec { 'pulp-consumer-register':
       command => "/usr/bin/pulp-consumer -u ${pulp::consumer::pulp_login} -p ${pulp::consumer::pulp_password} register --consumer-id ${pulp::consumer::id} --display-name ${pulp::consumer::display_name}",

--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -46,8 +46,8 @@ class pulp::globals (
                 gpgcheck => $repo_gpgcheck
             }
             # For compatibility with yum module
-            if $priority != 0 {
-              Yumrepo['Pulp repo'] { priority => $repo_priority }
+            if $::priority != 0 {
+                Yumrepo['Pulp repo'] { priority => $repo_priority }
             }
         }
         default: {


### PR DESCRIPTION
I solved some of the TravisCI warnings...
We still have errors of this kind:

```
foo::bar not in autoload module layout
```

but they are due to the folder name witch is `puppet_deployment` instead of `pulp`

What do we want to do? Disable the warning or find a way to let travis clone inside a dir called `pulp`?
