### PR TITLE
Use the new build env on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,20 @@
 ---
 language: ruby
-bundler_args: --without development
-before_install: rm Gemfile.lock || true
+
 rvm:
   - 1.8.7
   - 1.9.3
   - 2.0.0
-  - 2.1.0
+  - 2.1
+
+sudo: false
+
+bundler_args: --without development
+
+before_install: rm Gemfile.lock || true
+
 script: bundle exec rake test
+
 env:
   - PUPPET_VERSION="~> 2.7.0"
   - PUPPET_VERSION="~> 3.2.0"
@@ -15,17 +22,18 @@ env:
   - PUPPET_VERSION="~> 3.4.0"
   - PUPPET_VERSION="~> 3.5.0"
   - PUPPET_VERSION="~> 3.6.0"
+
 matrix:
   exclude:
   - rvm: 1.9.3
     env: PUPPET_VERSION="~> 2.7.0"
   - rvm: 2.0.0
     env: PUPPET_VERSION="~> 2.7.0"
-  - rvm: 2.1.0
+  - rvm: 2.1
     env: PUPPET_VERSION="~> 2.7.0"
-  - rvm: 2.1.0
+  - rvm: 2.1
     env: PUPPET_VERSION="~> 3.2.0"
-  - rvm: 2.1.0
+  - rvm: 2.1
     env: PUPPET_VERSION="~> 3.3.0"
-  - rvm: 2.1.0
+  - rvm: 2.1
     env: PUPPET_VERSION="~> 3.4.0"


### PR DESCRIPTION
more ram, dedicated cpu cores, better networking, awesome boot times
update the excludes in the .travis.yml

This PR squashes the two commits from https://github.com/pulp/puppet_deployment/pull/13.