### PR TITLE
Fix the proxy_url in templates to be actual proxy_host class parameter

### DIFF
--- a/templates/plugins/docker_importer.json
+++ b/templates/plugins/docker_importer.json
@@ -1,5 +1,5 @@
 {
-    "proxy_host": "<%= @proxy_url %>",
+    "proxy_host": "<%= @proxy_host %>",
     <%- if @proxy_port %>
     "proxy_port": <%= @proxy_port %>,
     <% else %>

--- a/templates/plugins/iso_importer.json
+++ b/templates/plugins/iso_importer.json
@@ -1,5 +1,5 @@
 {
-    "proxy_host": "<%= @proxy_url %>",
+    "proxy_host": "<%= @proxy_host %>",
     <%- if @proxy_port %>
     "proxy_port": <%= @proxy_port %>,
     <% else %>

--- a/templates/plugins/puppet_importer.json
+++ b/templates/plugins/puppet_importer.json
@@ -1,5 +1,5 @@
 {
-    "proxy_host": "<%= @proxy_url %>",
+    "proxy_host": "<%= @proxy_host %>",
     <%- if @proxy_port %>
     "proxy_port": <%= @proxy_port %>,
     <% else %>

--- a/templates/plugins/yum_importer.json
+++ b/templates/plugins/yum_importer.json
@@ -1,5 +1,5 @@
 {
-    "proxy_host": "<%= @proxy_url %>",
+    "proxy_host": "<%= @proxy_host %>",
     <%- if @proxy_port %>
     "proxy_port": <%= @proxy_port %>,
     <% else %>


### PR DESCRIPTION
Seems like there is an erroneous variable `proxy_url` used in all of the importer templates instead of the actual `proxy_host` that is being assigned as a parameter in the class `pulp::server`. This PR should fix it.