### PR TITLE
versioncmp specifies that arguments are strings

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -25,7 +25,7 @@ class pulp::repo (
             }
         }
         'RedHat', 'CentOS': {
-            if versioncmp($::facterversion, 2.0) < 0 {
+            if versioncmp($::facterversion, '2.0') < 0 {
                 package { 'redhat-lsb':
                     ensure => 'installed'
                 }


### PR DESCRIPTION
This change becomes required when using the future parser in puppet 3. I expect it would also be necessary when using puppet 4.