### PR TITLE
a rpm repo provider

### DIFF
--- a/lib/puppet/provider/pulp_rpmrepo/api.rb
+++ b/lib/puppet/provider/pulp_rpmrepo/api.rb
@@ -1,0 +1,209 @@
+require File.expand_path('../../../util/pulp_util', __FILE__)
+
+Puppet::Type.type(:pulp_rpmrepo).provide(:api) do
+  commands :pulp_admin => '/usr/bin/pulp-admin'
+
+  mk_resource_methods
+
+  # special getter methods for parameters that receive a file and write the content
+  [:feed_ca_cert,
+    :feed_cert,
+    :feed_key,
+    :gpg_key,
+    :host_ca,
+    :auth_ca,
+    :auth_cert,].each do |method|
+    method = method.to_sym
+    define_method method do
+      if resource[method] && File.read(resource[method]) == @property_hash[method]
+        resource[method]
+      else
+        nil
+      end
+    end
+  end
+
+  # this gets called for each resource
+  def initialize(resource={})
+    super(resource)
+    @property_flush = {}
+  end
+
+  def sym_to_bool(sym)
+    if sym == :true
+      true
+    elsif sym == :false
+      false
+    else
+      sym
+    end
+  end
+
+  def hash_to_params(params_hash)
+    param = nil
+    params = []
+    params_hash.each { |k, v|
+      if ! (v.nil? || "#{v}".empty?)
+        if v.kind_of?(Array)
+          param = [k, v.join(',')]
+        elsif v.kind_of?(Hash)
+          v.to_a.each { |pair|
+            param << [k, pair.join('=')]
+          }
+        else
+          param = [k, sym_to_bool(v)]
+        end
+        params << param
+      end
+    }
+    params
+  end
+
+  def self.get_resource_properties(repo_id)
+    hash = {}
+
+    repo = @pulp.get_repo_info(repo_id)
+    if !repo
+      hash[:ensure] = :absent
+      return
+    end
+
+    hash[:display_name] = repo['display_name']
+    hash[:description] = repo['description']
+    hash[:note] = repo['notes']
+    hash[:note].delete('_repo-type')
+
+    repo['distributors'].each { |distributor|
+      if distributor['id'] == 'yum_distributor'
+        hash[:relative_url]     = distributor['config']['relative_url']
+        hash[:serve_http]       = distributor['config']['http'] ? :true : :false
+        hash[:serve_https]      = distributor['config']['https'] ? :true : :false
+        hash[:checksum_type]    = distributor['config']['checksum_type']
+        hash[:gpg_key]          = distributor['config']['gpgkey']
+        hash[:generate_sqlite]  = distributor['config']['generate_sqlite'] ? :true : :false
+        hash[:auth_ca]          = distributor['config']['auth_ca']
+        hash[:auth_cert]        = distributor['config']['auth_cert']
+        hash[:host_ca]          = distributor['config']['https_ca']
+      end
+    }
+
+    repo['importers'].each { |importer|
+      if importer['id'] == 'yum_importer'
+        hash[:feed]             = importer['config']['feed']
+        hash[:validate]         = importer['config']['validate'] ? :true : :false
+        hash[:skip]             = importer['config']['type_skip_list']
+        hash[:feed_ca_cert]     = importer['config']['ssl_ca_cert']
+        hash[:verify_feed_ssl]  = importer['config']['ssl_validation'] ? :true : :false
+        hash[:feed_cert]        = importer['config']['ssl_client_cert']
+        hash[:feed_key]         = importer['config']['ssl_client_key']
+        hash[:proxy_host]       = importer['config']['proxy_host']
+        hash[:proxy_port]       = importer['config']['proxy_port']
+        hash[:proxy_user]       = importer['config']['proxy_username']
+        hash[:proxy_pass]       = importer['config']['proxy_password']
+        hash[:max_downloads]    = importer['config']['max_downloads']
+        hash[:max_speed]        = importer['config']['max_speed']
+        hash[:remove_missing]   = importer['config']['remove_missing'] ? :true : :false
+        hash[:retain_old_count] = importer['config']['retain_old_count']
+      end
+    }
+
+    hash[:name] = repo_id
+    hash[:ensure] = :present
+    hash[:provider] = :pulp_rpmrepo
+
+    Puppet.debug "Repo properties: #{hash.inspect}"
+
+    hash
+  end
+
+  def self.instances
+    all=[]
+    @pulp = Puppet::Util::PulpUtil.new
+    @pulp.get_repos.each { |repo|
+      next if repo['notes']['_repo-type'] != 'rpm-repo'
+      hash_properties = get_resource_properties(repo['id'])
+      all << new(hash_properties)
+    }
+    all
+  end
+
+  def exists?
+    @property_hash[:ensure] == :present
+  end
+
+  def create
+    @property_flush[:ensure] = :present
+  end
+
+  def destroy
+    @property_flush[:ensure] = :absent
+  end
+
+  # iterates through the array of resources returned by self.instances
+  def self.prefetch(resources)
+    instances.each do |prov|
+      if resource = resources[prov.name]
+        resource.provider = prov
+      end
+    end
+  end
+
+  def set_repo
+    params_hash = {
+      '--display-name'     => resource[:display_name],
+      '--description'      => resource[:description],
+      '--note'             => resource[:note],
+      '--feed'             => resource[:feed],
+      '--validate'         => resource[:validate],
+      '--skip'             => resource[:skip],
+      '--feed-ca-cert'     => resource[:feed_ca_cert],
+      '--verify-feed-ssl'  => resource[:verify_feed_ssl],
+      '--feed-cert'        => resource[:feed_cert],
+      '--feed-key'         => resource[:feed_key],
+      '--proxy-host'       => resource[:proxy_host],
+      '--proxy-port'       => resource[:proxy_port],
+      '--proxy-user'       => resource[:proxy_user],
+      '--proxy-pass'       => resource[:proxy_pass],
+      '--max-downloads'    => resource[:max_downloads],
+      '--max-speed'        => resource[:max_speed],
+      '--remove-missing'   => resource[:remove_missing],
+      '--retain-old-count' => resource[:retain_old_count],
+      '--relative-url'     => resource[:relative_url],
+      '--serve-http'       => resource[:serve_http],
+      '--serve-https'      => resource[:serve_https],
+      '--checksum-type'    => resource[:checksum_type],
+      '--gpg-key'          => resource[:gpg_key],
+      '--generate-sqlite'  => resource[:generate_sqlite],
+      '--host-ca'          => resource[:host_ca],
+      '--auth-ca'          => resource[:auth_ca],
+      '--auth-cert'        => resource[:auth_cert],
+    }
+
+    params= []
+
+    if @property_flush[:ensure] == :absent
+      # delete
+      action = 'delete'
+    elsif @property_flush[:ensure] == :present
+      # create
+      action = 'create'
+      params = hash_to_params(params_hash)
+    else
+      #update
+      action = 'update'
+      params = hash_to_params(params_hash)
+    end
+
+    arr = ['rpm', 'repo', action, '--repo-id', resource[:name], params]
+    pulp_admin(arr.flatten)
+  end
+
+  def flush
+    set_repo
+
+    # Collect the resources again once they've been changed (that way `puppet
+    # resource` will show the correct values after changes have been made).
+    @property_hash = self.class.get_resource_properties(resource[:name])
+  end
+
+end

--- a/lib/puppet/type/pulp_rpmrepo.rb
+++ b/lib/puppet/type/pulp_rpmrepo.rb
@@ -4,6 +4,11 @@ Puppet::Type.newtype(:pulp_rpmrepo) do
   @doc = <<-EOT
     doc 
   EOT
+
+  autorequire(:file) do
+    ['/etc/pulp/admin/admin.conf']
+  end
+
   def munge_boolean(value)
     case value
     when true, "true", :true

--- a/lib/puppet/type/pulp_rpmrepo.rb
+++ b/lib/puppet/type/pulp_rpmrepo.rb
@@ -1,0 +1,231 @@
+# curl -E ~/.pulp/user-cert.pem "https://$(hostname)/pulp/api/v2/repositories/epel_el6/?details=True" | python -mjson.tool
+
+Puppet::Type.newtype(:pulp_rpmrepo) do
+  @doc = <<-EOT
+    doc 
+  EOT
+  def munge_boolean(value)
+    case value
+    when true, "true", :true
+      :true
+    when false, "false", :false
+      :false
+    else
+      fail("munge_boolean only takes booleans")
+    end
+  end
+
+  def munge_integer(value)
+    Integer(value)
+  rescue ArgumentError
+    fail("munge_integer only takes integers")
+  end
+
+  ensurable do
+    desc <<-EOS
+      Create/Remove pulp rpm repo.
+    EOS
+
+    newvalue(:present) do
+      provider.create
+    end
+
+    newvalue(:absent) do
+      provider.destroy
+    end
+
+    defaultto :present
+  end
+
+  newparam(:name, :namevar => true) do
+    desc "repo-id: uniquely identifies the rpm repo"
+  end
+
+  newparam(:conf_file) do
+    desc "path to pulp-admin's config file. Defaults to /etc/pulp/admin/admin.conf"
+    defaultto('/etc/pulp/admin/admin.conf')
+  end
+
+  newproperty(:display_name) do
+    desc "user-readable display name (may contain i18n characters)"
+    defaultto do
+      @resource[:name]
+    end
+  end
+
+  newproperty(:description) do
+    desc "user-readable description (may contain i18n characters)"
+  end
+
+  newproperty(:note) do
+    desc "adds/updates/deletes notes to programmatically identify the  resource"
+    validate do |value|
+      if !value.kind_of?(Hash)
+        raise ArgumentError,
+        "Note property should be a hash"
+      end
+    end
+  end
+
+  newproperty(:feed) do
+    desc "URL of the external source repository to sync"
+  end
+
+  newproperty(:validate, :boolean => true) do
+    desc 'if "true", the size and checksum of each synchronized file will
+    be verified against the repo metadata'
+    #  defaultto :false
+    newvalues(:true, :false)
+    munge do |value|
+      @resource.munge_boolean(value)
+    end
+  end
+
+  newproperty(:skip, :array_matching => :all) do
+    desc "comma-separated list of types to omit when synchronizing, if not
+    specified all types will be synchronized; valid values are: rpm,
+    drpm, distribution, erratum"
+    newvalues(:rpm, :drpm, :distribution, :erratum)
+  end
+
+  newproperty(:feed_ca_cert) do
+    desc "full path to the CA certificate that should be used to
+    verify the external repo server's SSL certificate"
+  end
+
+  newproperty(:verify_feed_ssl, :boolean => true) do
+    desc 'if "true", the feed\'s SSL certificate will be verified
+    against the feed_ca_cert'
+    # defaultto :false
+    newvalues(:true, :false)
+    munge do |value|
+      @resource.munge_boolean(value)
+    end
+  end
+
+  newproperty(:feed_cert) do
+    desc "full path to the certificate to use for authorization when
+    accessing the external feed"
+  end
+
+  newproperty(:feed_key) do
+    desc "full path to the private key for feed_cert"
+  end
+
+  newproperty(:proxy_host) do
+    desc "proxy server url to use"
+  end
+
+  newproperty(:proxy_port) do
+    desc "port on the proxy server to make requests"
+    newvalues(/^\d+$/)
+    munge do |value|
+      @resource.munge_integer(value)
+    end
+  end
+
+  newproperty(:proxy_user) do
+    desc "username used to authenticate with the proxy server"
+  end
+
+  newproperty(:proxy_pass) do
+    desc "password used to authenticate with the proxy server"
+  end
+
+  newproperty(:max_downloads) do
+    desc "maximum number of downloads that will run concurrently"
+    newvalues(/^\d+$/)
+    munge do |value|
+      @resource.munge_integer(value)
+    end
+  end
+
+  newproperty(:max_speed) do
+    desc "maximum bandwidth used per download thread, in bytes/sec,
+    when synchronizing the repo"
+    newvalues(/^\d+$/)
+    munge do |value|
+      @resource.munge_integer(value)
+    end
+  end
+
+  newproperty(:remove_missing, :boolean => true) do
+    desc 'if "true", units that were previously in the external
+    feed but are no longer found will be removed from the  repository'
+    # defaultto false
+    newvalues(:true, :false)
+    munge do |value|
+      @resource.munge_boolean(value)
+    end
+  end
+
+  newproperty(:retain_old_count) do
+    desc "count indicating how many non-latest versions of a unit
+    to keep in a repository"
+    newvalues(/^\d+$/)
+    munge do |value|
+      @resource.munge_integer(value)
+    end
+  end
+
+  newproperty(:relative_url) do
+    desc "relative path the repository will be served from. Only
+    alphanumeric characters, forward slashes, underscores and
+    dashes are allowed. It defaults to the relative path of
+    the feed URL"
+    defaultto do
+      @resource[:name]
+    end
+  end
+
+  newproperty(:serve_http, :boolean => true) do
+    desc 'if "true", the repository will be served over HTTP'
+    defaultto :false
+    newvalues(:true, :false)
+    munge do |value|
+      @resource.munge_boolean(value)
+    end
+  end
+
+  newproperty(:serve_https, :boolean => true) do
+    desc 'if "true", the repository will be served over HTTPS'
+    defaultto :true
+    newvalues(:true, :false)
+    munge do |value|
+      @resource.munge_boolean(value)
+    end
+  end
+
+  newproperty(:checksum_type) do
+    desc "type of checksum to use during metadata generation"
+  end
+
+  newproperty(:gpg_key) do
+    desc "GPG key used to sign and verify packages in the repository"
+  end
+
+  newproperty(:generate_sqlite, :boolean => true) do
+    desc 'if "true", sqlite files will be generated for the  repository metadata during publish'
+    newvalues(:true, :false)
+    munge do |value|
+      @resource.munge_boolean(value)
+    end
+  end
+
+  newproperty(:host_ca) do
+    desc "full path to the CA certificate that signed the repository
+    hosts's SSL certificate when serving over HTTPS"
+  end
+
+  newproperty(:auth_ca) do
+    desc "full path to the CA certificate that should be used to verify
+    client authentication certificates; setting this turns on client
+    authentication for the repository"
+  end
+
+  newproperty(:auth_cert) do
+    desc "full path to the entitlement certificate that will be given to
+    bound consumers to grant access to this repository"
+  end
+
+end

--- a/lib/puppet/util/pulp_util.rb
+++ b/lib/puppet/util/pulp_util.rb
@@ -1,0 +1,114 @@
+require 'net/http'
+require 'net/https'
+require 'openssl'
+require 'uri'
+require 'json'
+
+module Puppet
+  module Util
+    class PulpUtil
+      def initialize (config_path = '/etc/pulp/admin/admin.conf')
+        config               = parse_config(config_path)
+        @config              = {}
+        @config[:host]       = config['server']['host']                 || Facter['fqdn'].value
+        @config[:port]       = config['server']['port']                 || 443
+        @config[:api_prefix] = config['server']['api_prefix']           || "/pulp/api"
+        @config[:cert_dir]   = config['filesystem']['id_cert_dir']      || "~/.pulp"
+        @config[:cert_file]  = config['filesystem']['id_cert_filename'] || "user-cert.pem"
+      end
+
+      def get_repos()
+        request_api('', false)
+      end
+
+      def get_repo_syncs(repo_id)
+        # returns an array with 2 values: an array of sync schedules and the repo type
+        raise 'Repo id should never be nil (get_repo_syncs)' if !repo_id
+        info = request_api(repo_id, false)
+        return info if !info
+
+        # we need to see the repo type first
+        case info['notes']['_repo-type']
+        when 'rpm-repo'
+          importer = 'yum_importer'
+        when 'puppet-repo'
+          importer = 'puppet_importer'
+        else
+          raise "Unknown repo type #{info[0]['notes']['_repo-type']}"
+        end
+
+        [request_api(repo_id, true, "/importers/#{importer}/schedules/sync/"), info['notes']['_repo-type']]
+      end
+
+      def get_repo_info(repo_id)
+        raise 'Repo id should never be nil (get_repo_info)' if !repo_id
+        request_api(repo_id, true)
+      end
+
+      private
+
+      def parse_config(path)
+        if File.file?(path)
+          settings = Hash.new
+          begin
+            file = File.new(path, "r")
+            while (line = file.gets)
+              if line =~ /(^#|^\s+$)/
+                # nada
+              elsif line =~ /^\[(.+)\]$/
+                section = $1
+                settings[section] = Hash.new
+              elsif line =~ /^[^\[]/
+                key, value = line.split(':')
+                settings[section][key] = value.strip
+              else
+                raise "I don't understand this line: #{line}"
+              end
+            end
+            file.close
+          rescue => err
+            puts "Exception: #{err}"
+          end
+
+          settings
+        end
+      end
+
+      def request_api(repo_id = nil, details = true, prefix = '')
+        begin
+          details_url = details ? '?details=True' : ''
+          repo_url    = repo_id && !repo_id.empty? ? "#{repo_id}/"   : ''
+          url         = "https://#{@config[:host]}:#{@config[:port]}#{@config[:api_prefix]}/v2/repositories/#{repo_url}/#{prefix}/#{details_url}"
+
+          # when running from mco, home is not set
+          begin
+            cert_path = File.expand_path("#{@config[:cert_dir]}/#{@config[:cert_file]}")
+          rescue
+            cert_path = File.expand_path("/root/.pulp/#{@config[:cert_file]}")
+          end
+          uri = URI(url)
+          uri.path.squeeze!("/")
+          cert_raw = File.read(cert_path)
+
+          req = Net::HTTP::Get.new(uri.request_uri)
+          https = Net::HTTP.new(uri.host, uri.port)
+          https.use_ssl = true
+          https.cert = OpenSSL::X509::Certificate.new(cert_raw)
+          https.key = OpenSSL::PKey::RSA.new(cert_raw)
+          https.verify_mode = OpenSSL::SSL::VERIFY_PEER
+          #  https.ca_file = '/etc/pki/ca-trust/source/anchors/puppet_ca.pem'
+          resp = https.request req
+
+          if resp.code == '200'
+            JSON.parse(resp.body)
+          else
+            nil
+          end
+        rescue Exception => e
+          raise Puppet::Error, "https request for #{repo_id} threw exception #{e.message}. Connection details: url=#{url}, cert_path=#{cert_path}."
+        end
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
Example usage:

    pulp_rpmrepo { 'pulp_el6':
      ensure           => 'present',
      checksum_type    => 'sha256',
      feed             => 'http://repos.fedorapeople.org/repos/pulp/pulp/stable/latest/6Server/x86_64/',
      generate_sqlite  => 'false',
      max_downloads    => '10',
      relative_url     => 'pulp/6Server',
      remove_missing   => 'true',
      retain_old_count => '1',
      serve_http       => 'true',
      serve_https      => 'true',
      validate         => 'true',
    }
