### PR TITLE
add vhost support

### DIFF
--- a/manifests/consumer.pp
+++ b/manifests/consumer.pp
@@ -49,6 +49,7 @@ class pulp::consumer (
     $msg_scheme        = 'tcp',
     $msg_host          = $::msg_host,
     $msg_port          = 5672,
+    $msg_vhost         = undef,
     $msg_transport     = rabbitmq,
     $msg_cacert        = undef,
     $msg_clientcert    = undef,

--- a/templates/etc/pulp/consumer.conf.erb
+++ b/templates/etc/pulp/consumer.conf.erb
@@ -144,6 +144,7 @@ wrap_width = <%= @wrap_width %>
 scheme = <%= @msg_scheme %>
 host = <%= @msg_host %>
 port = <%= @msg_port %>
+vhost = <%= @msg_vhost %>
 transport = <%= @msg_transport %>
 cacert = <%= @msg_cacert %>
 clientcert = <%= @msg_clientcert %>


### PR DESCRIPTION
Based on the pull request at https://github.com/pulp/pulp/pull/1987, this is the vhost support for the puppet module to configure the consumers