### PR TITLE
Pin rspec-core version to 3.1.7 (rspec/rspec-core#1864)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ group :test do
   gem "puppet", ENV['PUPPET_VERSION'] || '~> 3.7.0'
   gem "rspec-puppet", :git => 'https://github.com/rodjek/rspec-puppet.git'
   gem "puppetlabs_spec_helper"
+  gem 'rspec-core', '3.1.7'
 end
 
 group :development do


### PR DESCRIPTION
This fixes Travis builds on ruby 1.8.7. Unfortunately this is kind of a blunt change, but it appears to be the only simple way of supporting ruby 1.8.7 with older versions of Puppet.